### PR TITLE
chainable actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,32 @@ defmodule DashboardPage do
   end
 end
 
+# import the module so that actions can be chained together
+import DashboardPage
+
 # visit http://localhost:4001/account/1/dashboard?test_param=filter
 DashboardPage.visit_and_submit(1)
+
+# or chain actions
+DashboardPage
+|> visit(account_id: 1, test_param: "filter")
+|> submit
 
 # visit the page and update a form value
 DashboardPage.update_email("newemail@example.com")
 
+# or chain actions again
+DashboardPage
+|> visit(account_id: 1, test_param: "filter")
+|> fill_email("newemail@example.com")
+|> submit
+
 # confirm the value was updated
 assert DashboardPage.email == "newemail@example.com"
+
+# useful assertions for urls
+DashboardPage.visit(account_id: 3, test_param: "filter")
+assert current_url == DashboardPage.visit_url(account_id: 3, test_param: "filter")
 
 # click logout
 DashboardPage.logout

--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ For more API examples see the [tests](https://github.com/samueljseay/page_object
 Browser automation is handled by Hound but you'll also need phantomjs installed.
 
 1. `npm install -g phantomjs`
-2. `phantomjs --wd > /dev/null 2>&1 & mix test; && killall phantomjs`
+2. `phantomjs --wd > /dev/null 2>&1 & mix test; killall phantomjs`

--- a/lib/actions/clickable.ex
+++ b/lib/actions/clickable.ex
@@ -41,15 +41,17 @@ defmodule PageObject.Actions.Clickable do
       scope = Module.get_attribute(__MODULE__, :scope) || ""
 
       if (scope == "") do
-        def unquote(action_name)() do
+        def unquote(action_name)(module \\ __MODULE__) do
           find_element(:css, unquote(css_selector))
           |> click
+          module
         end
       else
-        def unquote(action_name)(el) do
+        def unquote(action_name)(module \\ __MODULE__, el) do
           el
           |> find_within_element(:css, unquote(css_selector))
           |> click
+          module
         end
       end
     end

--- a/lib/actions/fillable.ex
+++ b/lib/actions/fillable.ex
@@ -41,15 +41,17 @@ defmodule PageObject.Actions.Fillable do
       scope = Module.get_attribute(__MODULE__, :scope) || ""
 
       if (scope == "") do
-        def unquote(action_name)(value) do
+        def unquote(action_name)(module \\ __MODULE__, value) do
           find_element(:css, unquote(css_selector))
           |> fill_field(value)
+          module
         end
       else
-        def unquote(action_name)(el, value) do
+        def unquote(action_name)(module \\ __MODULE__, el, value) do
           el
           |> find_within_element(:css, unquote(css_selector))
           |> fill_field(value)
+          module
         end
       end
     end

--- a/lib/actions/visitable.ex
+++ b/lib/actions/visitable.ex
@@ -51,10 +51,20 @@ defmodule PageObject.Actions.Visitable do
         end)
       end
 
-      def unquote(action_name)(segments \\ []) do
+      def unquote(action_name)(module \\ __MODULE__, segments \\ [])
+
+      def unquote(action_name)(segments, _) when is_list(segments) do
         unquote(url)
         |> get_url(segments)
         |> navigate_to
+        __MODULE__
+      end
+
+      def unquote(action_name)(module, segments) do
+        unquote(url)
+        |> get_url(segments)
+        |> navigate_to
+        module
       end
 
       def unquote(:"#{action_name}_url")(segments \\ []) do

--- a/lib/queries/attribute.ex
+++ b/lib/queries/attribute.ex
@@ -44,6 +44,8 @@ defmodule PageObject.Queries.Attribute do
         def unquote(name)() do
           find_element(:css, unquote(css_selector))
           |> attribute_value(unquote(attr))
+          # some attributes give back inconsistent whitespace with different drivers, this eliminates that
+          |> String.trim
         end
       else
         def unquote(name)(el) do

--- a/lib/queries/attribute.ex
+++ b/lib/queries/attribute.ex
@@ -40,20 +40,22 @@ defmodule PageObject.Queries.Attribute do
     quote do
       scope = Module.get_attribute(__MODULE__, :scope) || ""
 
+      defp attribute(el, attr) do
+        attribute_value(el, attr)
+        # some attributes give back inconsistent whitespace with different drivers, this eliminates that
+        |> String.trim
+      end
+
       if scope == "" do
         def unquote(name)() do
           find_element(:css, unquote(css_selector))
-          |> attribute_value(unquote(attr))
-          # some attributes give back inconsistent whitespace with different drivers, this eliminates that
-          |> String.trim
+          |> attribute(unquote(attr))
         end
       else
         def unquote(name)(el) do
           el
           |> find_within_element(:css, unquote(css_selector))
-          |> attribute_value(unquote(attr))
-          # some attributes give back inconsistent whitespace with different drivers, this eliminates that
-          |> String.trim
+          |> attribute(unquote(attr))
         end
       end
     end

--- a/test/actions/clickable_test.exs
+++ b/test/actions/clickable_test.exs
@@ -1,22 +1,32 @@
+defmodule ClickablePage do
+  use PageObject
+
+  visitable :visit, "http://localhost:4000/index.html"
+  clickable :click_show, "#show-hidden"
+  attribute :hidden_style, "style", "#hidden"
+end
+
 defmodule ClickableTest do
   use ExUnit.Case
   use Hound.Helpers
 
   hound_session
 
-  defmodule IndexPage do
-    use PageObject
-
-    visitable :visit, "http://localhost:4000/index.html"
-    clickable :click_show, "#show-hidden"
-    attribute :hidden_style, "style", "#hidden"
-  end
+  import ClickablePage
 
   test "clicking the show-hidden button causes an element to come into view" do
-    IndexPage.visit
+    ClickablePage.visit
 
-    assert IndexPage.hidden_style == "display: none;"
-    IndexPage.click_show
-    assert IndexPage.hidden_style == "display: block;"
+    assert ClickablePage.hidden_style == "display: none;"
+    ClickablePage.click_show
+    assert ClickablePage.hidden_style == "display: block;"
+  end
+
+  test "chaining click and show works" do
+    ClickablePage
+      |> visit
+      |> click_show
+
+    assert ClickablePage.hidden_style == "display: block;"
   end
 end

--- a/test/actions/fillable_test.exs
+++ b/test/actions/fillable_test.exs
@@ -1,28 +1,31 @@
+defmodule IndexPage do
+  use PageObject
+
+  visitable :visit, "http://localhost:4000/index.html"
+
+  fillable :fill_email, "input[name='email']"
+  value :email_value, "input[name='email']"
+
+  fillable :fill_username, "input[name='username']"
+  value :username_value, "input[name='username']"
+
+  collection :things, item_scope: "ul .thing" do
+    value :text_input, "input[type='text']"
+    fillable :fill_input, "input[type='text']"
+  end
+end
+
 defmodule FillableTest do
   use ExUnit.Case
   use Hound.Helpers
 
   hound_session
 
-  defmodule IndexPage do
-    use PageObject
-
-    visitable :visit, "http://localhost:4000/index.html"
-
-    fillable :fill_email, "input[name='email']"
-    value :email_value, "input[name='email']"
-
-    fillable :fill_username, "input[name='username']"
-    value :username_value, "input[name='username']"
-
-    collection :things, item_scope: "ul .thing" do
-      value :text_input, "input[type='text']"
-      fillable :fill_input, "input[type='text']"
-    end
-  end
+  import IndexPage
 
   test "using fillable changes an input value" do
-    IndexPage.visit
+    IndexPage
+    |> visit
 
     assert IndexPage.email_value == "test@example.com"
     assert IndexPage.username_value == "testuser"
@@ -37,7 +40,8 @@ defmodule FillableTest do
   end
 
   test "fillable in a collection is scoped to the item_scope" do
-    IndexPage.visit
+    IndexPage
+    |> visit
 
     IndexPage.Things.get(3)
     |> IndexPage.Things.fill_input("a brand new value")
@@ -47,5 +51,13 @@ defmodule FillableTest do
       |> IndexPage.Things.text_input
 
     assert new_val == "a brand new value"
+  end
+
+  test "can chain visitable and fillable" do
+    IndexPage
+      |> visit
+      |> fill_email("new@example.com")
+
+    assert IndexPage.email_value == "new@example.com"
   end
 end

--- a/test/actions/visitable_test.exs
+++ b/test/actions/visitable_test.exs
@@ -1,28 +1,39 @@
+defmodule AccountPage do
+  use PageObject
+
+  visitable :visit, "http://localhost:4000/account/:account_id/view.html"
+end
+
 defmodule VisitableTest do
   use ExUnit.Case
   use Hound.Helpers
 
   hound_session
 
-  defmodule AccountPage do
-    use PageObject
-
-    visitable :visit, "http://localhost:4000/account/:account_id/view.html"
-  end
+  import AccountPage
 
   test "visiting the visitable with an account id inserts it into the url" do
-    AccountPage.visit(account_id: 1)
+    AccountPage
+    |> visit(account_id: 1)
 
     assert current_url == "http://localhost:4000/account/1/view.html"
   end
 
   test "visiting the visitable with query params inserts them into the url" do
-    AccountPage.visit(account_id: 2, param: "param1", other_param: "param2")
+    AccountPage
+    |> visit(account_id: 2, param: "param1", other_param: "param2")
 
     assert current_url == "http://localhost:4000/account/2/view.html?param=param1&other_param=param2"
   end
 
   test "can assert the current url using the visit_url method generated in the macro" do
+    AccountPage
+    |> visit(account_id: 2, param: "param1", other_param: "param2")
+
+    assert current_url == AccountPage.visit_url(account_id: 2, param: "param1", other_param: "param2")
+  end
+
+  test "can use the non-chained version of visit" do
     AccountPage.visit(account_id: 2, param: "param1", other_param: "param2")
 
     assert current_url == AccountPage.visit_url(account_id: 2, param: "param1", other_param: "param2")


### PR DESCRIPTION
Adds chainable actions via `import`. 

This is a more Elixir-ish API and also closer to the Selenium description of a page object, which
allows for chaining by definition.

In future I'd like to investigate chaining queries as well where they make sense.
