### PR TITLE
Add option to not clear before filling

### DIFF
--- a/lib/actions/fillable.ex
+++ b/lib/actions/fillable.ex
@@ -36,22 +36,43 @@ defmodule PageObject.Actions.Fillable do
     MyPage.Things.fillable("demo@example.com")
     ```
   """
-  defmacro fillable(action_name, css_selector, _opts \\ []) do
-    quote do
-      scope = Module.get_attribute(__MODULE__, :scope) || ""
+  defmacro fillable(action_name, css_selector, opts \\ []) do
+    if opts[:clear] == false do
+      quote do
+        scope = Module.get_attribute(__MODULE__, :scope) || ""
 
-      if (scope == "") do
-        def unquote(action_name)(module \\ __MODULE__, value) do
-          find_element(:css, unquote(css_selector))
-          |> fill_field(value)
-          module
+        if (scope == "") do
+          def unquote(action_name)(module \\ __MODULE__, value) do
+            find_element(:css, unquote(css_selector))
+            |> input_into_field(value)
+            module
+          end
+        else
+          def unquote(action_name)(module \\ __MODULE__, el, value) do
+            el
+            |> find_within_element(:css, unquote(css_selector))
+            |> input_into_field(value)
+            module
+          end
         end
-      else
-        def unquote(action_name)(module \\ __MODULE__, el, value) do
-          el
-          |> find_within_element(:css, unquote(css_selector))
-          |> fill_field(value)
-          module
+      end
+    else
+      quote do
+        scope = Module.get_attribute(__MODULE__, :scope) || ""
+
+        if (scope == "") do
+          def unquote(action_name)(module \\ __MODULE__, value) do
+            find_element(:css, unquote(css_selector))
+            |> fill_field(value)
+            module
+          end
+        else
+          def unquote(action_name)(module \\ __MODULE__, el, value) do
+            el
+            |> find_within_element(:css, unquote(css_selector))
+            |> fill_field(value)
+            module
+          end
         end
       end
     end

--- a/priv/static/index.html
+++ b/priv/static/index.html
@@ -36,6 +36,11 @@
     <input name="email" value="test@example.com">
     <input name="username" value="testuser">
 
+    <select name="choice">
+      <option value="vanilla">Vanilla</option>
+      <option value="chocolate">Chocolate</option>
+    </select>
+
     <button id="show-hidden" onClick="showHidden()">Show!</button>
     <div id="hidden" style="display:none;"><p>This is hidden</p></div>
 

--- a/test/actions/fillable_test.exs
+++ b/test/actions/fillable_test.exs
@@ -9,6 +9,9 @@ defmodule IndexPage do
   fillable :fill_username, "input[name='username']"
   value :username_value, "input[name='username']"
 
+  fillable :fill_choice, "select[name='choice']", clear: false
+  value :choice_value, "select[name='choice']"
+
   collection :things, item_scope: "ul .thing" do
     value :text_input, "input[type='text']"
     fillable :fill_input, "input[type='text']"
@@ -59,5 +62,13 @@ defmodule FillableTest do
       |> fill_email("new@example.com")
 
     assert IndexPage.email_value == "new@example.com"
+  end
+
+  test "can fill a select" do
+    IndexPage
+      |> visit
+      |> fill_choice("vanilla")
+
+    assert IndexPage.choice_value == "vanilla"
   end
 end


### PR DESCRIPTION
Hello, thanks so much for this library! I was wanting something like it in January as I’ve become fond of the pattern in Ember, so it’s nice to come back to Elixir and have it around.

I’ve found that I’m unable to use `fillable` to choose values from a `select` because Hound throws this error:

`Element must be user-editable in order to clear it.`

That’s because the underlying `fill_field` clears the element first and Hound doesn’t know how to do that with a `select`. So this is a naïve implementation with a `clear: false` option that will cause it to use Hound’s `input_into_field` instead.

I don’t propose that you actually merge this, I just want to get your feedback on what you think the interface should be, if you want to go ahead with supporting this use case. Since `ember-cli-page-object` already has a `selectable` action, I imagine that would be more in line with your plans?

While I’m here, do you have any thoughts about the `component`-type pattern of `ember-cli-page-object`? I used a nested module and it seems similar enough, does that seem worth documenting, or maybe it’s obvious to people with more Elixir experience?

I could also make another pull request with an `is_visible` query, which is something I’m missing. It can use [`Hound.Matchers.element?/2`](https://hexdocs.pm/hound/Hound.Matchers.html#element?/2).

Let me know your thoughts!