### PR TITLE
Add is_present? query

### DIFF
--- a/lib/page_object.ex
+++ b/lib/page_object.ex
@@ -10,7 +10,7 @@ defmodule PageObject do
       import PageObject
       import PageObject.Collections.Collection
       import PageObject.Actions.{Visitable, Clickable, Fillable, Selectable}
-      import PageObject.Queries.{Attribute, Text, Value}
+      import PageObject.Queries.{Attribute, IsPresent, Text, Value}
     end
   end
 end

--- a/lib/queries/is_present.ex
+++ b/lib/queries/is_present.ex
@@ -1,0 +1,57 @@
+defmodule PageObject.Queries.IsPresent do
+  @moduledoc """
+    A module wrapper for the is_present? query macro
+  """
+
+  @doc """
+    Defines a module function that determines the presence of an element on an html page. The function name is derived
+    by `name`. When scoped to a collection the function takes an element as an argument.
+
+    ## Example
+
+    ```
+    #not in a collection
+    defmodule MyPage do
+      use PageObject
+
+      is_present? :warning_is_present?, ".warning"
+    end
+
+    # returns whether an element with class "warning" is present on the page
+    MyPage.warning_is_present?
+    ```
+
+    ```
+    #in a collection
+    defmodule MyPage do
+      use PageObject
+
+      collection :things, item_scope: ".thing" do
+        is_present? :error_is_present?, ".error"
+      end
+    end
+
+    # returns whether an element with class "error" exists within the 0th ".thing"
+    MyPage.Things.get(0)
+    |> MyPage.Things.error_is_present?
+    ```
+  """
+  defmacro is_present?(name, css_selector, _opts \\ []) do
+    quote do
+      scope = Module.get_attribute(__MODULE__, :scope) || ""
+
+      if scope == "" do
+        def unquote(name)() do
+          Hound.Matchers.element?(:css, unquote(css_selector))
+        end
+      else
+        def unquote(name)(el) do
+          case search_within_element(el, :css, unquote(css_selector), 1) do
+            {:error, _} -> false
+            {:ok, _} -> true
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/actions/is_present_test.exs
+++ b/test/actions/is_present_test.exs
@@ -1,0 +1,43 @@
+defmodule IsPresentPage do
+  require Logger
+
+  use PageObject
+
+  visitable :visit, "http://localhost:4000/index.html"
+  is_present? :heading_is_present?, "h2"
+  is_present? :hidden_is_present?, "#hidden"
+  is_present? :footer_is_present?, "footer"
+
+  collection :things, item_scope: "ul .thing" do
+    is_present? :select_is_present?, "select"
+  end
+end
+
+defmodule IsPresentTest do
+  use ExUnit.Case
+  use Hound.Helpers
+
+  hound_session
+
+  test "is_present? detects whether an element is present" do
+    IsPresentPage.visit
+
+    assert IsPresentPage.heading_is_present?
+    assert IsPresentPage.hidden_is_present?
+    refute IsPresentPage.footer_is_present?
+  end
+
+  test "is_present? in a collection is scoped to the item_scope" do
+    IsPresentPage.visit
+
+    third_select_present? = IsPresentPage.Things.get(2)
+      |> IsPresentPage.Things.select_is_present?
+
+    refute third_select_present?
+
+    fourth_select_present? = IsPresentPage.Things.get(3)
+      |> IsPresentPage.Things.select_is_present?
+
+    assert fourth_select_present?
+  end
+end


### PR DESCRIPTION
Hey! While I suggested `is_visible` in #5, I realised I really wanted `is_present`, as I want to know whether the element is on the page, not whether it’s visible. I also called it `is_present?` since it’s a boolean, but if you prefer `is_present` alone, I can change that.

I wasn’t able to use  [`Hound.Matchers.element?/2`](https://hexdocs.pm/hound/Hound.Matchers.html#element?/2) for the scoped query, so I used [`Hound.Helpers.Page.search_within_element/4`](https://hexdocs.pm/hound/Hound.Helpers.Page.html#search_within_element/4) with a `retries` of 1, which works like a scoped `element?`. It’s less elegant band feels a bit hacking, but it permits the same functionality within a collection. What do you think?