### PR TITLE
Fix warnings generated by generating duplicate private methods

### DIFF
--- a/lib/queries/attribute.ex
+++ b/lib/queries/attribute.ex
@@ -40,22 +40,20 @@ defmodule PageObject.Queries.Attribute do
     quote do
       scope = Module.get_attribute(__MODULE__, :scope) || ""
 
-      defp attribute(el, attr) do
-        attribute_value(el, attr)
-        # some attributes give back inconsistent whitespace with different drivers, this eliminates that
-        |> String.trim
-      end
-
       if scope == "" do
         def unquote(name)() do
           find_element(:css, unquote(css_selector))
-          |> attribute(unquote(attr))
+          |> attribute_value(unquote(attr))
+          # some attributes give back inconsistent whitespace with different drivers, this eliminates that
+          |> String.trim
         end
       else
         def unquote(name)(el) do
           el
           |> find_within_element(:css, unquote(css_selector))
-          |> attribute(unquote(attr))
+          |> attribute_value(unquote(attr))
+          # some attributes give back inconsistent whitespace with different drivers, this eliminates that
+          |> String.trim
         end
       end
     end


### PR DESCRIPTION
When attribute was called multiple times in a module it was generating a duplicate private method that caused pattern match warnings. Favoured adding back some repetition over generating multiple duplicate methods.