### PR TITLE
Add is_selected? helper

### DIFF
--- a/lib/page_object.ex
+++ b/lib/page_object.ex
@@ -10,7 +10,7 @@ defmodule PageObject do
       import PageObject
       import PageObject.Collections.Collection
       import PageObject.Actions.{Visitable, Clickable, Fillable, Selectable}
-      import PageObject.Queries.{Attribute, IsPresent, Text, Value}
+      import PageObject.Queries.{Attribute, IsPresent, IsSelected, Text, Value}
     end
   end
 end

--- a/lib/queries/is_selected.ex
+++ b/lib/queries/is_selected.ex
@@ -1,0 +1,57 @@
+defmodule PageObject.Queries.IsSelected do
+  @moduledoc """
+    A module wrapper for the is_selected? query macro
+  """
+
+  @doc """
+    Defines a module function that determines if a radio button or a checkbox element on an html page is checked. The function name is derived
+    by `name`. When scoped to a collection the function takes an element as an argument.
+
+    ## Example
+
+    ```
+    #not in a collection
+    defmodule MyPage do
+      use PageObject
+
+      is_selected? :is_service_agreement_accepted?, ".service-agreement"
+    end
+
+    # returns whether the element ".service-agreement" is checked on the page
+    MyPage.is_service_agreement_accepted?
+    ```
+
+    ```
+    #in a collection
+    defmodule MyPage do
+      use PageObject
+
+      collection :things, item_scope: ".thing" do
+        is_selected? :is_checked?, ".checkbox"
+      end
+    end
+
+    # returns whether an element with class ".checkbox" is checked within the 0th ".thing"
+    MyPage.Things.get(0)
+    |> MyPage.Things.is_checked?
+    ```
+  """
+  defmacro is_selected?(name, css_selector, _opts \\ []) do
+    quote do
+      scope = Module.get_attribute(__MODULE__, :scope) || ""
+
+      if scope == "" do
+        def unquote(name)() do
+          Hound.Helpers.Element.selected?({:css, unquote(css_selector)})
+        end
+      else
+        def unquote(name)(el) do
+          case search_within_element(el, :css, unquote(css_selector)) do
+            {:error, _} -> false
+            {:ok, element} -> Hound.Helpers.Element.selected?(element)
+          end
+        end
+      end
+    end
+  end
+end

--- a/priv/static/index.html
+++ b/priv/static/index.html
@@ -31,11 +31,16 @@
       <li class="thing">
         <a class="title" data-special-attr="thing-5">Thing #5</a>
         <input type="text" class="thing-input" value="thing-5-value" >
+        <input type="checkbox" checked="checked" class="thing-checkbox">
       </li>
     </ul>
 
-    <input type="radio" checked="checked" id="radio-attribute-1" >
+    <input type="radio" checked="checked" id="radio-attribute-1">
+    <input type="radio" id="radio-attribute-2">
     <input type="text" placeholder="placeholder text" id="input-attribute-1">
+
+    <input type="checkbox" checked="checked" id="checkbox-1">
+    <input type="checkbox" id="checkbox-2">
 
     <input name="email" value="test@example.com">
     <input name="username" value="testuser">

--- a/test/queries/is_selected_test.exs
+++ b/test/queries/is_selected_test.exs
@@ -1,0 +1,43 @@
+defmodule IsSelectedPage do
+  use PageObject
+
+  visitable :visit, "http://localhost:4000/index.html"
+
+  is_selected? :radio_1_selected?, "#radio-attribute-1"
+  is_selected? :radio_2_selected?, "#radio-attribute-2"
+
+  is_selected? :checkbox_1_selected?, "#checkbox-1"
+  is_selected? :checkbox_2_selected?, "#checkbox-2"
+
+  collection :things, item_scope: "ul .thing" do
+    is_selected? :checkbox_selected?, ".thing-checkbox"
+  end
+end
+
+defmodule IsSelectedTest do
+  use ExUnit.Case
+  use Hound.Helpers
+
+  hound_session
+
+  test "is_selected? detects whether an element is checked" do
+    IsSelectedPage.visit
+
+    assert IsSelectedPage.radio_1_selected?
+    refute IsSelectedPage.radio_2_selected?
+    assert IsSelectedPage.checkbox_1_selected?
+    refute IsSelectedPage.checkbox_2_selected?
+  end
+
+  test "is_selected? in a collection is scoped to the item_scope" do
+    IsSelectedPage.visit
+
+    first_thing = IsSelectedPage.Things.get(0)
+
+    refute IsSelectedPage.Things.checkbox_selected?(first_thing)
+
+    fifth_thing = IsSelectedPage.Things.get(4)
+
+    assert IsSelectedPage.Things.checkbox_selected?(fifth_thing)
+  end
+end


### PR DESCRIPTION
We found really useful in our project to been able to check if an element is selected or not using Hound's `selected?` helper.

This PR adds the `is_selected?` helper to page objects so it's easier to use inside collections.

```ex
defmodule MyPage do
  use PageObject

  is_selected? :is_service_agreement_accepted?, ".service-agreement"
end

# returns whether the element ".service-agreement" is checked on the page
MyPage.is_service_agreement_accepted?
```