### PR TITLE
Add is_visible? helper

### DIFF
--- a/lib/page_object.ex
+++ b/lib/page_object.ex
@@ -10,7 +10,7 @@ defmodule PageObject do
       import PageObject
       import PageObject.Collections.Collection
       import PageObject.Actions.{Visitable, Clickable, Fillable, Selectable}
-      import PageObject.Queries.{Attribute, IsPresent, IsSelected, Text, Value}
+      import PageObject.Queries.{Attribute, IsPresent, IsSelected, IsVisible, Text, Value}
     end
   end
 end

--- a/lib/queries/is_visible.ex
+++ b/lib/queries/is_visible.ex
@@ -1,0 +1,67 @@
+defmodule PageObject.Queries.IsVisible do
+  @moduledoc """
+    A module wrapper for the is_visible? query macro
+  """
+
+  @doc """
+    Defines a module function that determines when an element exists and is visible on the page. 
+    The function name is derived by `name`. When scoped to a collection the function takes an
+    element as an argument.
+
+    ## Example
+
+    ```
+    #not in a collection
+    defmodule MyPage do
+      use PageObject
+
+      is_visible? :modal_is_visible?, ".modal"
+    end
+
+    # returns whether an element with class "modal" exists and is visible on the page
+    MyPage.modal_is_visible?
+    ```
+
+    ```
+    #in a collection
+    defmodule MyPage do
+      use PageObject
+
+      collection :things, item_scope: ".thing" do
+        is_visible? :error_is_visible?, ".error"
+      end
+    end
+
+    # returns whether an element with class "error" exists and is visible within the 0th ".thing"
+    MyPage.Things.get(0)
+    |> MyPage.Things.error_is_visible?
+    ```
+  """
+  defmacro is_visible?(name, css_selector, _opts \\ []) do
+    quote do
+      scope = Module.get_attribute(__MODULE__, :scope) || ""
+
+      if scope == "" do
+        def unquote(name)() do
+          with {:ok, el} <- Hound.Helpers.Page.search_element(:css, unquote(css_selector), 1),
+               true <- Hound.Helpers.Element.element_displayed?(el)
+          do
+            true
+          else
+            _ -> false
+          end
+        end
+      else
+        def unquote(name)(parent) do
+          with {:ok, el} <- Hound.Helpers.Page.search_within_element(parent, :css, unquote(css_selector), 1),
+               true <- Hound.Helpers.Element.element_displayed?(el)
+          do
+            true
+          else
+            _ -> false
+          end
+        end
+      end
+    end
+  end
+end

--- a/priv/static/index.html
+++ b/priv/static/index.html
@@ -33,6 +33,9 @@
         <input type="text" class="thing-input" value="thing-5-value" >
         <input type="checkbox" checked="checked" class="thing-checkbox">
       </li>
+      <li class="thing">
+        <a class="title" style="display: none;" data-special-attr="thing-6">Thing #6</a>
+      </li>
     </ul>
 
     <input type="radio" checked="checked" id="radio-attribute-1">

--- a/test/collections/collection_test.exs
+++ b/test/collections/collection_test.exs
@@ -25,7 +25,7 @@ defmodule CollectionTest do
 
   test "collection is scoped to the item_scope" do
     IndexPage.visit
-    assert Enum.count(IndexPage.Things.all) == 5
+    assert Enum.count(IndexPage.Things.all) == 6
   end
 
   test "collection names are camelized" do
@@ -55,6 +55,6 @@ defmodule CollectionTest do
   test "collection defined without a block still behaves as expected" do
     IndexPage.visit
 
-    assert Enum.count(IndexPage.Things.all) == 5
+    assert Enum.count(IndexPage.Things.all) == 6
   end
 end

--- a/test/queries/is_visible_test.exs
+++ b/test/queries/is_visible_test.exs
@@ -1,0 +1,43 @@
+defmodule IsVisiblePage do
+  require Logger
+
+  use PageObject
+
+  visitable :visit, "http://localhost:4000/index.html"
+  is_visible? :heading_is_visible?, "h2"
+  is_visible? :hidden_is_visible?, "#hidden"
+  is_visible? :footer_is_visible?, "footer"
+
+  collection :things, item_scope: "ul .thing" do
+    is_visible? :title_is_visible?, ".title"
+  end
+end
+
+defmodule IsVisibleTest do
+  use ExUnit.Case
+  use Hound.Helpers
+
+  hound_session
+
+  test "is_visible? returns true if the element exists and is visible" do
+    IsVisiblePage.visit
+
+    assert IsVisiblePage.heading_is_visible?
+    refute IsVisiblePage.hidden_is_visible?
+    refute IsVisiblePage.footer_is_visible?
+  end
+
+  test "is_visible? in a collection is scoped to the item_scope" do
+    IsVisiblePage.visit
+
+    third_title_visible? = IsVisiblePage.Things.get(2)
+      |> IsVisiblePage.Things.title_is_visible?
+
+    assert third_title_visible?
+
+    sixth_title_visible? = IsVisiblePage.Things.get(5)
+      |> IsVisiblePage.Things.title_is_visible?
+
+    refute sixth_title_visible?
+  end
+end


### PR DESCRIPTION
Hi! In our project we found useful to have a helper to detect when an element is visible or not.

This implementation of `is_visible?` follows the original ember-cli-page-object's behavior: returns true when the element exists and is visible. 
When the element doesn't exists it doesn't throws any exception.

